### PR TITLE
use function already loaded in contract

### DIFF
--- a/eth_client/lib/eth_client/contract.ex
+++ b/eth_client/lib/eth_client/contract.ex
@@ -6,6 +6,8 @@ defmodule EthClient.Contract do
 
   defstruct [:address, :functions]
 
+  def get_functions, do: EthClient.Context.contract.functions
+
   def get_functions(address_or_path) do
     with {:ok, abi} <- ABI.get(address_or_path) do
       parse_abi(abi)


### PR DESCRIPTION
Create `EthClient.Contract.get_functions/0` that returns the functions already loaded in the context contract.