### PR TITLE
Add function to check if a transaction is a deploy

### DIFF
--- a/eth_client/lib/eth_client.ex
+++ b/eth_client/lib/eth_client.ex
@@ -119,6 +119,21 @@ defmodule EthClient do
     {:ok, tx_hash}
   end
 
+  def contract_deploy?(transaction) when is_number(transaction) do
+    transaction
+    |> Integer.to_string(16)
+    |> add_0x
+    |> contract_deploy?()
+  end
+
+  def contract_deploy?(transaction) when is_binary(transaction) do
+    case Rpc.get_transaction_receipt(transaction) do
+      {:ok, %{"contractAddress" => nil}} -> false
+      {:ok, %{"contractAddress" => _}} -> true
+      {:error, msg} -> {:error, msg}
+    end
+  end
+
   defp nonce(address) do
     {nonce, ""} =
       Rpc.get_transaction_count(address)


### PR DESCRIPTION
This PR adds a function to check if a given transaction is a contract deploy or not.